### PR TITLE
Update hoist-non-react-statics to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/airbnb/react-create-hoc#readme",
   "dependencies": {
     "airbnb-prop-types": "^2.10.0",
-    "hoist-non-react-statics": "^2.5.5",
+    "hoist-non-react-statics": "^3.3.0",
     "object.assign": "^4.1.0",
     "prop-types-exact": "^1.2.0"
   },


### PR DESCRIPTION
### summary

Allows use of React 16.3+ features like contextTypes.
The major version bump was due to dropping support for React < 0.14, so
this is not a major change.

https://github.com/mridgway/hoist-non-react-statics/blob/master/CHANGELOG.md#300-july-27-2018

### reviewers

@ljharb 